### PR TITLE
Update clash-prelude to 3c7f92a 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ install:
     echo 'source-repository-package'                                    >> cabal.project
     echo '  type: git'                                                  >> cabal.project
     echo '  location: https://github.com/clash-lang/clash-compiler'     >> cabal.project
-    echo '  tag: 1111111111111111111111111111111111111111'              >> cabal.project
+    echo '  tag: 3c7f92ad2357a577467ec84df61fffa36843cb50'              >> cabal.project
     echo '  subdir: clash-prelude'                                      >> cabal.project
     echo ''                                                             >> cabal.project
     echo 'source-repository-package'                                    >> cabal.project
@@ -138,7 +138,7 @@ script:
     echo 'source-repository-package'                                    >> cabal.project
     echo '  type: git'                                                  >> cabal.project
     echo '  location: https://github.com/clash-lang/clash-compiler'     >> cabal.project
-    echo '  tag: 1111111111111111111111111111111111111111'              >> cabal.project
+    echo '  tag: 3c7f92ad2357a577467ec84df61fffa36843cb50'              >> cabal.project
     echo '  subdir: clash-prelude'                                      >> cabal.project
     echo ''                                                             >> cabal.project
     echo 'source-repository-package'                                    >> cabal.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,20 @@ install:
     fi
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
   - "printf 'packages: \".\"\\n' > cabal.project"
+
+  # Add specific clash-prelude  / ghc-typelits-extra
+  - |
+    echo 'source-repository-package'                                    >> cabal.project
+    echo '  type: git'                                                  >> cabal.project
+    echo '  location: https://github.com/clash-lang/clash-compiler'     >> cabal.project
+    echo '  tag: 1111111111111111111111111111111111111111'              >> cabal.project
+    echo '  subdir: clash-prelude'                                      >> cabal.project
+    echo ''                                                             >> cabal.project
+    echo 'source-repository-package'                                    >> cabal.project
+    echo '  type: git'                                                  >> cabal.project
+    echo '  location: https://github.com/clash-lang/ghc-typelits-extra' >> cabal.project
+    echo '  tag: a8de0b68b8216411cb862195354f251cd41bae50'              >> cabal.project
+
   - "printf 'package clash-cosim\\n  flags: +pedantic\\n' > cabal.project.local"
   - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- clash-cosim | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true
@@ -119,6 +133,19 @@ script:
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: clash-cosim-*/*.cabal\\n' > cabal.project"
+  # Add specific clash-prelude  / ghc-typelits-extra
+  - |
+    echo 'source-repository-package'                                    >> cabal.project
+    echo '  type: git'                                                  >> cabal.project
+    echo '  location: https://github.com/clash-lang/clash-compiler'     >> cabal.project
+    echo '  tag: 1111111111111111111111111111111111111111'              >> cabal.project
+    echo '  subdir: clash-prelude'                                      >> cabal.project
+    echo ''                                                             >> cabal.project
+    echo 'source-repository-package'                                    >> cabal.project
+    echo '  type: git'                                                  >> cabal.project
+    echo '  location: https://github.com/clash-lang/ghc-typelits-extra' >> cabal.project
+    echo '  tag: a8de0b68b8216411cb862195354f251cd41bae50'              >> cabal.project
+
   - "printf 'package clash-cosim\\n  flags: +pedantic\\n' > cabal.project.local"
   - "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- clash-cosim | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
   - cat cabal.project || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,8 @@ install:
       (cd "." && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - cabal new-build --write-ghc-environment-files=always -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
+  - cabal new-build --write-ghc-environment-files=always -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
@@ -113,7 +113,7 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
   # test that source-distributions can be generated
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
+  - cabal new-build --write-ghc-environment-files=always -w ${HC} --disable-tests --disable-benchmarks all
   - (cd "." && cabal new-sdist)
   - mv "."/dist-newstyle/sdist/clash-cosim-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
@@ -124,10 +124,10 @@ script:
   - cat cabal.project || true
   - cat cabal.project.local || true
   # this builds all libraries and executables (without tests/benchmarks)
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
+  - cabal new-build --write-ghc-environment-files=always -w ${HC} --disable-tests --disable-benchmarks all
 
   # build & run tests, build benchmarks
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
+  - cabal new-build --write-ghc-environment-files=always -w ${HC} ${TEST} ${BENCH} all
   - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
   # cabal check
@@ -138,7 +138,7 @@ script:
   - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
 
   # Build without installed constraints for packages in global-db
-  - if $UNCONSTRAINED; then rm -f cabal.project.local; echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks all; else echo "Not building without installed constraints"; fi
+  - if $UNCONSTRAINED; then rm -f cabal.project.local; echo cabal new-build --write-ghc-environment-files=always -w ${HC} --disable-tests --disable-benchmarks all; else echo "Not building without installed constraints"; fi
 
 # REGENDATA ["--irc-channel","irc.freenode.org#clash-lang","./clash-cosim.cabal"]
 # EOF

--- a/cabal.project
+++ b/cabal.project
@@ -19,7 +19,7 @@ repository head.hackage
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler
-  tag: 1111111111111111111111111111111111111111
+  tag: 3c7f92ad2357a577467ec84df61fffa36843cb50
   subdir: clash-prelude
 
 -- | We need: a <=? Max a b ~ True

--- a/cabal.project
+++ b/cabal.project
@@ -18,8 +18,15 @@ repository head.hackage
 
 source-repository-package
   type: git
-  location: https://github.com/clash-lang/clash-prelude
-  tag: bd0c50b7e8051fcfb9318cc70971f48daa8b56da
+  location: https://github.com/clash-lang/clash-compiler
+  tag: 1111111111111111111111111111111111111111
+  subdir: clash-prelude
+
+-- | We need: a <=? Max a b ~ True
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/ghc-typelits-extra
+  tag: a8de0b68b8216411cb862195354f251cd41bae50
 
 -- Build documentation for all dependencies so we can upload docs to hackage
 -- with proper links

--- a/cabal.project
+++ b/cabal.project
@@ -29,3 +29,6 @@ package *
 -- The fail package is empty for GHC 8+, and haddock errors out on it
 package fail
   documentation: False
+
+package clash-prelude
+  documentation: False

--- a/src/Clash/CoSim/Simulator.hs
+++ b/src/Clash/CoSim/Simulator.hs
@@ -43,7 +43,6 @@ import Foreign
 import Foreign.C
 
 -- GC / IO / Monad
-import Control.DeepSeq (NFData)
 import Control.Monad
 import System.IO.Unsafe
 import System.Mem
@@ -419,6 +418,6 @@ class CoSimType t where
     toSignalStream   :: t -> SignalStream
     fromSignalStream :: SignalStream -> t
 
-instance (ClashType a, NFData a) => CoSimType (CP.Signal clk a) where
+instance (ClashType a, CP.Undefined a) => CoSimType (CP.Signal clk a) where
     toSignalStream   = map (wordPack . CP.pack) . CP.sample
     fromSignalStream = CP.fromList . map (CP.unpack . wordUnpack)

--- a/src/Clash/CoSim/Types.hs
+++ b/src/Clash/CoSim/Types.hs
@@ -12,9 +12,9 @@ be housed in Simulator.hs, but FFI code crashes Template Haskell.
 module Clash.CoSim.Types where
 
 import Data.Data (Data, Typeable)
-import Control.DeepSeq (NFData)
 
 import Clash.Prelude (BitPack, BitSize, KnownNat)
+import Clash.XException (Undefined)
 
 -- | Settings passed to the simulator. Does not affect synthetization.
 data CoSimSettings = CoSimSettings
@@ -45,7 +45,7 @@ defaultSettings = CoSimSettings
 -- can be simultated.
 type ClashType a = ( BitPack a
                    , KnownNat (BitSize a)
-                   , NFData a
+                   , Undefined a
                    )
 
 -- | Supported simulators

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -4,10 +4,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}
 
-import Control.DeepSeq (NFData)
-
 import Clash.Prelude
 import Clash.Prelude.Testbench
+import Clash.XException (Undefined)
 import Clash.CoSim (verilog, verilogWithSettings, period, defaultSettings)
 
 import Data.List as L
@@ -30,7 +29,7 @@ tests = testGroup "Inline verilog"
 -- "normal" Haskell types.
 bin
     :: forall t a
-     . (t ~ Signal System a, NFData a)
+     . (t ~ Signal System a, Undefined a)
     => (t -> t -> t)
     -> a
     -> a


### PR DESCRIPTION
See: https://github.com/clash-lang/clash-compiler/pull/579. 

The commit `eada464` fails "on purpose" due to a dependency loop that's fixed in the later commit. (`clash-cosim` shouldn't be a separate repository!)