### PR TITLE
Remove redundant import

### DIFF
--- a/tests/test.hs
+++ b/tests/test.hs
@@ -6,7 +6,6 @@
 
 import Clash.Prelude
 import Clash.Prelude.Testbench
-import Clash.XException (Undefined)
 import Clash.CoSim (verilog, verilogWithSettings, period, defaultSettings)
 
 import Data.List as L


### PR DESCRIPTION
`Undefined` is already implicitly imported from Clash.Prelude.
And GHC-8.8 started warning about such redundant imports.